### PR TITLE
chore: Use fluencebot PAT to commit doc changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.FLUENCEBOT_RELEASE_PLEASE_PAT }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2.2.4


### PR DESCRIPTION
When commit was done using GITHUB_TOKEN CI will not be triggered making PR impossible to merge.

Using PAT to commit will trigger CI but will cancel previous runs.